### PR TITLE
Add Practice API endpoints

### DIFF
--- a/FreeAgent.postman_collection.json
+++ b/FreeAgent.postman_collection.json
@@ -1,10 +1,138 @@
 {
 	"info": {
-		"_postman_id": "5920a0b8-0def-4706-b83d-4825a54fea7f",
+		"_postman_id": "bd310f58-3b13-4e89-9633-5e90a7eec531",
 		"name": "FreeAgent",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
+		{
+			"name": "Accountancy Practice API",
+			"item": [
+				{
+					"name": "List all clients",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/v2/clients",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"v2",
+								"clients"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "List all account managers",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/v2/account_managers",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"v2",
+								"account_managers"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get a single account manager",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/v2/account_managers/:id",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"v2",
+								"account_managers",
+								":id"
+							],
+							"variable": [
+								{
+									"key": "id",
+									"value": ""
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "ed99bf79-0de4-4481-b052-4001acca34c2",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "b0678d4c-65d6-4f8a-b39e-cb35b6a59f36",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
 		{
 			"name": "Attachments",
 			"item": [


### PR DESCRIPTION
Adds queries for the three practice-specific API endpoints currently available in the FreeAgent API (List all clients, List all account managers, Get a single account manager).