### PR TITLE
Correct OAuth Redirect URIs used by postman

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,25 @@
 Please refer to the official FreeAgent API docs:
 https://dev.freeagent.com/docs
 
+> **IMPORTANT:** postman is available as a web application (https://www.postman.com/) or a desktop application running on Windows, Mac etc. The web application has a different OAuth 2.0 redirect URI to the desktop application. 
+
 ### Get Started
 
-1. Import the FreeAgent collection
+1. Create an application using your [FreeAgent Developer Dashboard](https://dev.freeagent.com/). Ensure the following **OAuth redirect URIs** are listed (add them if missing). They can be listed in any order.
+- https://developers.google.com/oauthplayground
+- https://oauth.pstmn.io/v1/browser-callback
+- https://www.getpostman.com/oauth2/callback
 
-2. Import the environment file(s) for sandbox and/or production. Fill in the environment variables for `client_id`
-and `client_secret` from your app, which you can create via our [Developer Dashboard](https://dev.freeagent.com).
+    The google URI is not required for this postman collection but if you want to use your application with the [Google OAuth Playground](https://developers.google.com/oauthplayground/) - as described in the [FreeAgent Developer Quick Start](https://dev.freeagent.com/docs/quick_start) - then you need it.
 
-  - Your app on the Developer Dashboard should list `https://www.getpostman.com/oauth2/callback` as a permitted OAuth Redirect URI (this will be done for you automatically when you create a new app)
+    The `oauth.pstmn.io` URL is required for the postman web application. The last one is required for the postman desktop application. Listing all 3 means you are good for any scenario.
 
-3. Then generate an access and refresh tokens by:
+2. Import the FreeAgent collection
+
+3. Import the environment file(s) for sandbox and/or production (but see [Common Postman Gotchas](#common-postman-gotchas) below). Fill in the environment variables for `client_id`
+and `client_secret` from your app (which you created in step 1).
+
+4. Generate access and refresh tokens by:
 - right-clicking on the collection > Edit > `Authorization`
 - click `Get New Access Token`, signing in with an account for the appropriate environment, then click `Proceed`
 - and finally `Use Token`.
@@ -25,6 +34,27 @@ If your attempt to obtain an access token fails with the `"HTTP Basic: Access de
 
 - FreeAgent App Signup for Sandbox:
   - https://signup.sandbox.freeagent.com
+
+#### Common Postman Gotchas
+
+The web and desktop applications work slightly differently e.g. you right-click items in the desktop app but in the web app you single-click icons.
+
+I think the web application is more usable as it caches the username & password you enter when filling out the application authorization web form, so saving typing. You also get browser developr tools for free!
+
+##### Environment Variables Not Working Correctly
+
+There is an outstanding postman bug where environment variables are not resolved when sending requests:
+[Environment variable not being resolved when sending request #6001](https://github.com/postmanlabs/postman-app-support/issues/6001)
+
+There are a number of work-arounds. The simplest is to:
+- Import the environment as described above (so you know what variables are defined)
+- Create a new environment manually; define the required variables in the new environment
+- Delete the imported environment
+
+##### Environment Is INACTIVE By Default
+
+You need to tick the checkbox next to the environment to mark it as **active** so that its variables will be resolved by the Postman collection.
+
 
 ### Refreshing the Access Token Automatically
 


### PR DESCRIPTION
1. The previous version of README.md was written for the postman desktop application. There is now a postman web application that uses a different OAuth Redirect URI. Fix the instructions to explain this.

2. Highlight gotchas with postman's buggy handling of variables used by the collection.